### PR TITLE
added logic for adjusted claims

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -28,27 +28,30 @@ vars:
   source_name: colorado_apacd           # configuration required
                                         # name describing the dataset feeding this project
 
-  input_database: tuva                  # configuration required
+  input_database:                     # configuration required
                                         # name of the database where sources feeding this project are stored
 
-  input_schema: colorado_apacd          # configuration required
+  input_schema: COAPCD          # configuration required
                                         # name of the schema where sources feeding this project is stored
 
-  output_database: tuva                 # configuration required
+  output_database:                    # configuration required
                                         # name of the database where output of this project should be written
 
-  output_schema: claim_input            # configuration required
+  output_schema: COAPCD_tuva            # configuration required
                                         # name of the schema where output of this project should be written
 
-    member_demographics: "{{ source(var('source_name'),'member_demographics') }}"
-    member_eligibility: "{{ source(var('source_name'),'member_eligibility') }}"
-    medical_claims_header: "{{ source(var('source_name'),'medical_claims_header') }}"
-    medical_claims_line: "{{ source(var('source_name'),'medical_claims_line') }}"
-    medical_claims_dx: "{{ source(var('source_name'),'medical_claims_dx') }}"
-    medical_claims_procedures: "{{ source(var('source_name'),'medical_claims_procedures') }}"
-    claim_level_value_add_drg: "{{ source(var('source_name'),'claim_level_value_add_drg') }}"
-
+  member_demographics: "{{ source(var('source_name'),'Members') }}"
+  member_eligibility: "{{ source(var('source_name'),'Member_Eligibility') }}"
+  medical_claims_header: "{{ source(var('source_name'),'Medical_Claims_Header') }}"
+  medical_claims_line: "{{ source(var('source_name'),'medical_claims_line') }}"
+  medical_claims_dx: "{{ source(var('source_name'),'Medical_Claims_Dx') }}"
+  medical_claims_procedures: "{{ source(var('source_name'),'Medical_Claims_Procedures') }}"
+  claim_level_value_add_drg: "{{ source(var('source_name'),'Claim_Level_Value_Add_DRG') }}"
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
-
+models:
+  colorado_apacd_connector:
+    # Applies to all files under models/example/
+    example:
+      materialized: view

--- a/models/core/medical_claim.sql
+++ b/models/core/medical_claim.sql
@@ -133,10 +133,158 @@ select
     ,cast(px.procedure_date_25 as date) as procedure_date_25
 from {{ var('medical_claims_header')}} h
 inner join {{ var('medical_claims_line')}} d
-	on cl.claim_id = h.claim_id
+	on d.claim_id = h.claim_id
 left join {{ ref('procedure_pivot')}} px
 	on h.claim_id = px.claim_id
 left join {{ ref('diagnosis_pivot')}} dx
 	on h.claim_id = dx.claim_id
-left join {{ var('diagnosis_related_groups_drg')}} drg
+left join {{ var('claim_level_value_add_drg')}} drg
+	on h.claim_id = drg.claim_id
+left join {{ ref('duplicate_claims')}} dupe
+    on h.claim_id = dupe.claim_id
+where dupe.claim_id is null   
+
+union
+
+select
+    cast(h.claim_id as varchar) as claim_id
+    ,cast(d.line_no as int) as claim_line_number
+    ,cast(h.member_id as varchar) as patient_id
+    ,cast(h.service_start_dt as date) as claim_start_date
+    ,cast(h.service_end_dt as date) as claim_end_date
+    ,cast(h.admit_dt as date) as admission_date
+    ,cast(h.dishcarge_dt as date) as discharge_date
+    ,cast(d.service_start_dt as date) as claim_line_start_date
+    ,cast(d.service_end_dt as date) as claim_line_end_date
+    ,cast(h.claim_type_cd as varchar) as claim_type
+    ,cast(h.bill_type_cd as varchar) as bill_type_code
+    ,cast(d.place_of_service_cd as varchar) as place_of_service_code
+    ,cast(h.admit_source_cd as varchar) as admit_source_code
+    ,cast(h.admit_type_cd as varchar) as admit_type_code
+    ,cast(h.discharge_status_cd as varchar) as discharge_disposition_code
+    ,cast(drg.msdrg_cd as varchar) as ms_drg
+    ,cast(d.revenue_cd as varchar) as revenue_center_code
+    ,cast(d.service_qty as int) as service_unit_quantity
+    ,cast(d.cpt4_cd as varchar) as hcpcs_code
+    ,cast(d.cpt4_mod1_cd as varchar) as hcpcs_modifier_1
+    ,cast(d.cpt4_mod2_cd as varchar) as hcpcs_modifier_2
+    ,cast(d.cpt4_mod3_cd as varchar) as hcpcs_modifier_3
+    ,cast(d.cpt4_mod4_cd as varchar) as hcpcs_modifier_4
+    ,cast(null as varchar) as hcpcs_modifier_5
+    ,cast(d.service_provider_id as varchar) as physician_npi
+    ,cast(d.service_provider_id as varchar) as facility_npi
+    ,cast(h.paid_date as date) as paid_date
+    ,cast(d.plan_paid_amt as float) as paid_amount
+    ,cast(d.charge_amt as float) as charge_amount
+    ,cast(null as varchar) as adjustment_type_code
+    ,cast(dx.diagnosis_code_1 as varchar) as diagnosis_code_1
+    ,cast(dx.diagnosis_code_2 as varchar) as diagnosis_code_2
+    ,cast(dx.diagnosis_code_3 as varchar) as diagnosis_code_3
+    ,cast(dx.diagnosis_code_4 as varchar) as diagnosis_code_4
+    ,cast(dx.diagnosis_code_5 as varchar) as diagnosis_code_5
+    ,cast(dx.diagnosis_code_6 as varchar) as diagnosis_code_6
+    ,cast(dx.diagnosis_code_7 as varchar) as diagnosis_code_7
+    ,cast(dx.diagnosis_code_8 as varchar) as diagnosis_code_8
+    ,cast(dx.diagnosis_code_9 as varchar) as diagnosis_code_9
+    ,cast(dx.diagnosis_code_10 as varchar) as diagnosis_code_10
+    ,cast(dx.diagnosis_code_11 as varchar) as diagnosis_code_11
+    ,cast(dx.diagnosis_code_12 as varchar) as diagnosis_code_12
+    ,cast(dx.diagnosis_code_13 as varchar) as diagnosis_code_13
+    ,cast(dx.diagnosis_code_14 as varchar) as diagnosis_code_14
+    ,cast(dx.diagnosis_code_15 as varchar) as diagnosis_code_15
+    ,cast(dx.diagnosis_code_16 as varchar) as diagnosis_code_16
+    ,cast(dx.diagnosis_code_17 as varchar) as diagnosis_code_17
+    ,cast(dx.diagnosis_code_18 as varchar) as diagnosis_code_18
+    ,cast(dx.diagnosis_code_19 as varchar) as diagnosis_code_19
+    ,cast(dx.diagnosis_code_20 as varchar) as diagnosis_code_20
+    ,cast(dx.diagnosis_code_21 as varchar) as diagnosis_code_21
+    ,cast(dx.diagnosis_code_22 as varchar) as diagnosis_code_22
+    ,cast(dx.diagnosis_code_23 as varchar) as diagnosis_code_23
+    ,cast(dx.diagnosis_code_24 as varchar) as diagnosis_code_24
+    ,cast(dx.diagnosis_code_25 as varchar) as diagnosis_code_25
+    ,cast(dx.diagnosis_poa_1 as varchar) as diagnosis_poa_1
+    ,cast(dx.diagnosis_poa_2 as varchar) as diagnosis_poa_2
+    ,cast(dx.diagnosis_poa_3 as varchar) as diagnosis_poa_3
+    ,cast(dx.diagnosis_poa_4 as varchar) as diagnosis_poa_4
+    ,cast(dx.diagnosis_poa_5 as varchar) as diagnosis_poa_5
+    ,cast(dx.diagnosis_poa_6 as varchar) as diagnosis_poa_6
+    ,cast(dx.diagnosis_poa_7 as varchar) as diagnosis_poa_7
+    ,cast(dx.diagnosis_poa_8 as varchar) as diagnosis_poa_8
+    ,cast(dx.diagnosis_poa_9 as varchar) as diagnosis_poa_9
+    ,cast(dx.diagnosis_poa_10 as varchar) as diagnosis_poa_10
+    ,cast(dx.diagnosis_poa_11 as varchar) as diagnosis_poa_11
+    ,cast(dx.diagnosis_poa_12 as varchar) as diagnosis_poa_12
+    ,cast(dx.diagnosis_poa_13 as varchar) as diagnosis_poa_13
+    ,cast(dx.diagnosis_poa_14 as varchar) as diagnosis_poa_14
+    ,cast(dx.diagnosis_poa_15 as varchar) as diagnosis_poa_15
+    ,cast(dx.diagnosis_poa_16 as varchar) as diagnosis_poa_16
+    ,cast(dx.diagnosis_poa_17 as varchar) as diagnosis_poa_17
+    ,cast(dx.diagnosis_poa_18 as varchar) as diagnosis_poa_18
+    ,cast(dx.diagnosis_poa_19 as varchar) as diagnosis_poa_19
+    ,cast(dx.diagnosis_poa_20 as varchar) as diagnosis_poa_20
+    ,cast(dx.diagnosis_poa_21 as varchar) as diagnosis_poa_21
+    ,cast(dx.diagnosis_poa_22 as varchar) as diagnosis_poa_22
+    ,cast(dx.diagnosis_poa_23 as varchar) as diagnosis_poa_23
+    ,cast(dx.diagnosis_poa_24 as varchar) as diagnosis_poa_24
+    ,cast(dx.diagnosis_poa_25 as varchar) as diagnosis_poa_25
+    ,cast(dx.icd_vers_flag as varchar) as diagnosis_code_type
+    ,cast(px.icd_vers_flag as varchar) as procedure_code_type
+    ,cast(px.procedure_code_1 as varchar) as procedure_code_1
+    ,cast(px.procedure_code_2 as varchar) as procedure_code_2
+    ,cast(px.procedure_code_3 as varchar) as procedure_code_3
+    ,cast(px.procedure_code_4 as varchar) as procedure_code_4
+    ,cast(px.procedure_code_5 as varchar) as procedure_code_5
+    ,cast(px.procedure_code_6 as varchar) as procedure_code_6
+    ,cast(px.procedure_code_7 as varchar) as procedure_code_7
+    ,cast(px.procedure_code_8 as varchar) as procedure_code_8
+    ,cast(px.procedure_code_9 as varchar) as procedure_code_9
+    ,cast(px.procedure_code_10 as varchar) as procedure_code_10
+    ,cast(px.procedure_code_11 as varchar) as procedure_code_11
+    ,cast(px.procedure_code_12 as varchar) as procedure_code_12
+    ,cast(px.procedure_code_13 as varchar) as procedure_code_13
+    ,cast(px.procedure_code_14 as varchar) as procedure_code_14
+    ,cast(px.procedure_code_15 as varchar) as procedure_code_15
+    ,cast(px.procedure_code_16 as varchar) as procedure_code_16
+    ,cast(px.procedure_code_17 as varchar) as procedure_code_17
+    ,cast(px.procedure_code_18 as varchar) as procedure_code_18
+    ,cast(px.procedure_code_19 as varchar) as procedure_code_19
+    ,cast(px.procedure_code_20 as varchar) as procedure_code_20
+    ,cast(px.procedure_code_21 as varchar) as procedure_code_21
+    ,cast(px.procedure_code_22 as varchar) as procedure_code_22
+    ,cast(px.procedure_code_23 as varchar) as procedure_code_23
+    ,cast(px.procedure_code_24 as varchar) as procedure_code_24
+    ,cast(px.procedure_code_25 as varchar) as procedure_code_25
+    ,cast(px.procedure_date_1 as date) as procedure_date_1
+    ,cast(px.procedure_date_2 as date) as procedure_date_2
+    ,cast(px.procedure_date_3 as date) as procedure_date_3
+    ,cast(px.procedure_date_4 as date) as procedure_date_4
+    ,cast(px.procedure_date_5 as date) as procedure_date_5
+    ,cast(px.procedure_date_6 as date) as procedure_date_6
+    ,cast(px.procedure_date_7 as date) as procedure_date_7
+    ,cast(px.procedure_date_8 as date) as procedure_date_8
+    ,cast(px.procedure_date_9 as date) as procedure_date_9
+    ,cast(px.procedure_date_10 as date) as procedure_date_10
+    ,cast(px.procedure_date_11 as date) as procedure_date_11
+    ,cast(px.procedure_date_12 as date) as procedure_date_12
+    ,cast(px.procedure_date_13 as date) as procedure_date_13
+    ,cast(px.procedure_date_14 as date) as procedure_date_14
+    ,cast(px.procedure_date_15 as date) as procedure_date_15
+    ,cast(px.procedure_date_16 as date) as procedure_date_16
+    ,cast(px.procedure_date_17 as date) as procedure_date_17
+    ,cast(px.procedure_date_18 as date) as procedure_date_18
+    ,cast(px.procedure_date_19 as date) as procedure_date_19
+    ,cast(px.procedure_date_20 as date) as procedure_date_20
+    ,cast(px.procedure_date_21 as date) as procedure_date_21
+    ,cast(px.procedure_date_22 as date) as procedure_date_22
+    ,cast(px.procedure_date_23 as date) as procedure_date_23
+    ,cast(px.procedure_date_24 as date) as procedure_date_24
+    ,cast(px.procedure_date_25 as date) as procedure_date_25
+from {{ var('medical_claims_header')}} h
+inner join {{ ref('adjusted_claim_final')}} d
+	on d.claim_id = h.claim_id
+left join {{ ref('procedure_pivot')}} px
+	on h.claim_id = px.claim_id
+left join {{ ref('diagnosis_pivot')}} dx
+	on h.claim_id = dx.claim_id
+left join {{ var('claim_level_value_add_drg')}} drg
 	on h.claim_id = drg.claim_id

--- a/models/core/medical_claim.yml
+++ b/models/core/medical_claim.yml
@@ -42,7 +42,6 @@ models:
         - name: revenue_center_code
           description: The provider-assigned revenue code for each cost center for which a separate charge is billed (type of accommodation or ancillary).  A cost center is a division or unit within a hospital (e.g., radiology, emergency room, pathology). Revenue center code 0001 represents the total of all revenue centers included on the claim.
         - name: service_unit_quantity
-          description: 
         - name: hcpcs_code
           description: The HCFA Common Procedure Coding System (HCPCS) code that represent procedures, supplies, products and services provided to beneficiary
         - name: hcpcs_modifier_1
@@ -168,9 +167,7 @@ models:
         - name: diagnosis_poa_25
           description: Claim diagnosis present on admission 25
         - name: diagnosis_code_type
-          description: 
         - name: procedure_code_type
-          description: 
         - name: procedure_code_1
           description: Claim procedure code 1
         - name: procedure_code_2

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -2,13 +2,13 @@ version: 2
 
 sources:
   - name: "{{ var('source_name') }}"
-    database: "{{ var('source_database') }}"
-    schema:  "{{ var('source_schema') }}"
+    database: "{{ var('input_database') }}"
+    schema:  "{{ var('input_schema') }}"
     tables:
-      - name: member_demographics
-      - name: member_eligibility
-      - name: medical_claims_header
+      - name: Members
+      - name: Member_Eligibility
+      - name: Medical_Claims_Header
       - name: medical_claims_line
-      - name: medical_claims_dx
-      - name: medical_claims_procedures
-      - name: claim_level_value_add_drg
+      - name: Medical_Claims_Dx
+      - name: Medical_Claims_Procedures
+      - name: Claim_Level_Value_Add_DRG

--- a/models/transformation/adjusted_claim_final.sql
+++ b/models/transformation/adjusted_claim_final.sql
@@ -1,0 +1,30 @@
+-------------------------------------------------------------------------------
+-- Author       Thu Xuan Vu
+-- Created      July 2022
+-- Purpose      Create a distinct list of adjusted and reversed claims.
+-- Notes        The extraction of reversed claims can be kept or removed based
+--                  on an organization's needs.
+-------------------------------------------------------------------------------
+-- Modification History
+--
+-------------------------------------------------------------------------------
+
+select
+    s.*
+from {{ ref('adjusted_claim_stage')}} s
+inner join {{ ref('adjusted_claim_validation')}} v
+    on s.claim_id = v.claim_id
+where adjustment_type = 'A'
+
+union all
+
+select 
+    s.*
+from {{ ref('adjusted_claim_stage')}} s
+inner join {{ ref('adjusted_claim_validation')}} v
+    on s.claim_id = v.claim_id
+where adjustment_type = 'R'
+and s.claim_id not in (select s.claim_id from {{ ref('adjusted_claim_stage')}} s 
+                                        inner join {{ ref('adjusted_claim_validation')}} v
+                                        on s.claim_id = v.claim_id 
+                                        where adjustment_type = 'A')

--- a/models/transformation/adjusted_claim_stage.sql
+++ b/models/transformation/adjusted_claim_stage.sql
@@ -1,0 +1,60 @@
+-------------------------------------------------------------------------------------------------
+-- Author       Thu Xuan Vu
+-- Created      July 2022
+-- Purpose      Identify duplicate claim lines and seperate out reversals, originals and adjustment.
+-- Notes        First, duplicate claim lines are identified
+--              Then, reversals for are identified.  The payments of these lines are negative.
+--              Next, the original lines are identified.  The charge or paid amount of an orginial
+--                is the same amount as the reversal
+--              Finally, the adjusted lines are identified.  This is the claim line that hasn't been
+--                flagged as original or reversal
+--              Edge cases:  Not all lines on a claim will be reversed.  These lines are definied
+--                as an adjustment so they are included in the final data set.
+--              Some duplicate claims do not have a reversal indicator so they are entirely removed.
+-------------------------------------------------------------------------------------------------
+-- Modification History
+--
+-------------------------------------------------------------------------------------------------
+
+with  reversals as(
+  select 
+    'R' as adjustment_type
+    , l.* 
+  from {{ ref('duplicate_claims')}} d
+  inner join {{ var('medical_claims_line')}} l
+    on d.claim_id = l.claim_id
+    and d.line_no = l.line_no
+  where (plan_paid_amt < 0
+  or charge_amt < 0)
+)
+, original as(
+select 'O' as adjustment_type, l.* 
+from reversals r
+inner join {{ var('medical_claims_line')}} l
+  on r.claim_id = l.claim_id
+  and r.line_no = l.line_no
+where r.plan_paid_amt * -1 = l.plan_paid_amt
+and r.charge_amt * -1 = l.charge_amt
+)
+, adjustment as(
+select 
+  'A' as adjustment_type
+  , l.* 
+from {{ var('medical_claims_line')}} l
+left join reversals r
+  on l.claim_id = r.claim_id
+  and l.line_no = r.line_no
+where l.claim_id in (select claim_id from reversals)
+and l.plan_paid_amt <> ifnull(r.plan_paid_amt,0)
+and l.plan_paid_amt <> ifnull(r.plan_paid_amt* -1,0)
+)
+, adjustment_union as(
+select * from reversals
+union all
+select * from original
+union all
+select * from adjustment
+)
+
+select * from adjustment_union
+where claim_id not in (select claim_id from adjustment_union group by claim_id, line_no, adjustment_type having count(*) > 1)

--- a/models/transformation/adjusted_claim_validation.sql
+++ b/models/transformation/adjusted_claim_validation.sql
@@ -1,0 +1,28 @@
+-------------------------------------------------------------------------------
+-- Author       Thu Xuan Vu
+-- Created      July 2022
+-- Purpose      Create a list of distinct claims.  Using the sum of claim line 
+--                payments and the claim header to validate the correct claim lines
+--                were identified/logic in prior step is working correctly
+-- Notes        Have confirmed that a properly adjusted claim does not
+--                always equal the header. (Reviewed the logic and math manually)
+--                However it felt like a good validation step and omits 18% claims
+--                (from the adjustment population).  Can be removed at an organization's discretion.
+-------------------------------------------------------------------------------
+-- Modification History
+--
+-------------------------------------------------------------------------------
+
+
+with total_payments as(
+  select s.claim_id
+  , sum(s.plan_paid_amt) as adjusted_payment_total
+  , max(h.plan_paid_amt) as header_total
+  from {{ ref('adjusted_claim_stage')}} s
+  inner join {{ var('medical_claims_header')}} h
+    on s.claim_id = h.claim_id
+  group by s.claim_id
+)
+
+select * from total_payments t
+where adjusted_payment_total = header_total

--- a/models/transformation/duplicate_claims.sql
+++ b/models/transformation/duplicate_claims.sql
@@ -1,0 +1,25 @@
+-------------------------------------------------------------------------------------------------
+-- Author       Thu Xuan Vu
+-- Created      July 2022
+-- Purpose      Create list of all claims with duplicate claim lines.
+-- Notes        
+-------------------------------------------------------------------------------------------------
+-- Modification History
+--
+-------------------------------------------------------------------------------------------------
+
+with duplicate_claims as(
+  select 
+    l.claim_id
+    , l.line_no
+  from {{ var('medical_claims_header')}}  h
+  inner join {{ var('medical_claims_line')}} l
+    on l.claim_id = h.claim_id 
+    and l.member_id = h.member_id
+  group by l.claim_id, l.line_no
+  having count(*) > 1
+)
+
+select distinct
+  claim_id 
+from duplicate_claims


### PR DESCRIPTION
added 4 queries to address duplicate claims (generally due to adjustment):

- duplicate_claims identifies all claims that have duplicate claim lines.  This subset will be analyzed for adjustments.  It will also be a filter.  Not all duplicate claims have enough info to identify the adjustment.
- adjustment_claim_stage identifies reversals, the original, and adjustment lines of a claim.  reversals have a negative payment amount, the original line as a positive payment amount that equals the reversal, and the adjustment is whatever is left over.  This does include claims lines that were not reversed.  
- adjustment_validation is a list of adjusted claims where the line payments equal the header payment.  I can confirm that a properly adjusted claim does not always equal the header.  Organization can remove this step if they deem this is not a necessary step
- adjustment_final is a copy of the medical_claim_line for adjusted claims only.
- medical_claim (not new) has been modified to union two queries:  header and detail info from the source data omitting all duplicate claims, and header and detail info for only claims in adjustment final